### PR TITLE
fix: Change the execution script on the client

### DIFF
--- a/docker/etc/bacula-dir.conf
+++ b/docker/etc/bacula-dir.conf
@@ -76,9 +76,11 @@ Job {
   # This creates an ASCII copy of the catalog
   # Arguments to make_catalog_backup.pl are:
   #  make_catalog_backup.pl <catalog-name>
-  RunBeforeJob = "/opt/bacula/scripts/make_catalog_backup.pl MyCatalog"
+  # RunBeforeJob = "/opt/bacula/scripts/make_catalog_backup.pl MyCatalog"
+  ClientRunBeforeJob = "/opt/bacula/scripts/make_catalog_backup.pl MyCatalog"
   # This deletes the copy of the catalog
-  RunAfterJob  = "/opt/bacula/scripts/delete_catalog_backup"
+  # RunAfterJob  = "/opt/bacula/scripts/delete_catalog_backup"
+  ClientRunAfterJob = "/opt/bacula/scripts/delete_catalog_backup"
   Write Bootstrap = "/opt/bacula/working/%n.bsr"
   Priority = 11                   # run after main backup
 }


### PR DESCRIPTION
O problema da issue #17 é por conta que as configurações RunBeforeJob e RunAfterJob são executados no container do bacula-dir e no momento da copia configurado no FileSert ele procura no container bacula-fd dessa forma para resolver esse problema basta trocar:

RunBeforeJob = "/opt/bacula/scripts/make_catalog_backup.pl MyCatalog"
RunAfterJob = "/opt/bacula/scripts/delete_catalog_backup"

por

ClientRunBeforeJob = "/opt/bacula/scripts/make_catalog_backup.pl MyCatalog"
ClientRunAfterJob = "/opt/bacula/scripts/delete_catalog_backup" 