### PR TITLE
Added the mt-st package to the bacula-base Dockerfile to resolve issue with autochanger

### DIFF
--- a/docker/bacula-base/Dockerfile
+++ b/docker/bacula-base/Dockerfile
@@ -25,7 +25,8 @@ RUN yum -y install \
 	postgresql10 \
 	zip \
 	bzip2 \
-	mtx 
+	mtx \
+	mt-st
 
 RUN yum install -y bacula-postgresql-$BACULA_VERSION --exclude=bacula-mysql
 


### PR DESCRIPTION
While trying to get my Dell PowerVault 124T working with the Docker files in this repository, I noticed that I was not able to complete the `autochanger` test that is included in the `btape` tool, as recommended by the [Bacula documentation](https://www.bacula.org/11.0.x-manuals/en/problems/Testing_Your_Tape_Drive_Wit.html)

The `btape` tool `autochanger` command would output the following:

```
=== Autochanger test ===

3301 Issuing autochanger "loaded" command.
Nothing loaded in the drive. OK.
```

While there **was** a drive loaded in drive number 0. As Bacula was wrongfully assuming that drive 0 was empty, it would try to load a drive from slot 1 into drive 0 , which would return the error `Drive 0 Full (Storage Element 1 loaded)`, while the `btape` tool would continue reporting
```
3303 Issuing autochanger "load 1 0" command.
```

Until a timeout was reached and the `autochanger` test failed.

The `btape` `autochanger` program calls a script `/opt/bacula/scripts/mtx-changer` in the `bacula-sd` container, which is a wrapper for the generic `mtx` command. This script is used to do all the interactions with the autochanger, acting as a proxy for `mtx`. 

When the `btape` `autochanger` command is ran, it calls the `mtx-changer` script with the `loaded` argument to probe if the drive is loaded. It expects a return value of `0` if the drive is empty, and a return value of `1` if the drive is full. On my setup, it issued the following command:

```
./mtx-changer /dev/sg8 loaded 1 /dev/st0 0
```

*Where `dev/sg8` is the autoloader SCSI device and `dev/st0` is the autoloader built-in SCSI tape drive.*

When `btape` tries to run this command inside the `bacula-sd` container, the output is not a pure `1` or `0`, but it also contains an error:

```
[root@86797ec3f40e scripts]# ./mtx-changer /dev/sg8 loaded 1 /dev/st0 0
/opt/bacula/scripts/mtx-changer.conf: line 84: mt: command not found
1
```

As the return value now contains an error besides the return value of `1`, the `btape` program wrongfully interprets this, thinking the drive is empty. It then tries to load a tape into the full drive, which results in the `autochanger` test failing.

*Note in the output above that the command is working correctly, as it returns a `1` while my drive was loaded at the time, it just also contains the error about the `mt` command, causing `btape` to interpret that the drive is empty 
 while it is actually full.*

The `/opt/bacula/scripts/mtx-changer.conf` is a configuration file for the `mtx-changer` script and tries to figure out what version of `mt` is installed on line 84 and 89 of the `mtx-changer.conf` file, which is where the error is generated. As the `mt-st` package is not installed in the `bacula-sd` container, the error `command not found` is generated, which causes the issues down the line.

This pull request adds the `mt-st` repository to the `bacula-base` Dockerfile, which prevents the error from popping up when using the `mtx-changer` script, which fixes the issue where the `autochanger` test is not able to complete because of the `command not found` error being wrongfully interpreted by `btape` as the autochanger having an empty drive, to which it tries to load a drive into an already occupied drive, failing the test.

The fact that `btape` wrongfully interprets the error generated by the  the `mtx-changer` script as the autochanger having an empty drive (which always will indicate an empty drive, regardless of the autochanger state if the `mt-st` package is not installed), is worth the bug report on the Bacula side, which I will try to file after this pull request.

